### PR TITLE
REFACTOR: Navigation-by-Keyboard Bug Fix/Heather's Notes

### DIFF
--- a/src/Header/Header.css
+++ b/src/Header/Header.css
@@ -20,8 +20,11 @@ header {
 .title-container {
   display: flex;
   align-items: center;
-  width: 152px;
   justify-content: space-around;
+  text-decoration: none;
+  width: 152px;
+  height: 43px;
+  margin: 22px 0px;
 }
 
 h1 {
@@ -29,7 +32,6 @@ h1 {
   font-size: 1.1em;
   line-height: 17px;
   color: #2e930c;
-  pointer-events: none;
 }
 
 .logo {

--- a/src/Header/Header.js
+++ b/src/Header/Header.js
@@ -1,5 +1,5 @@
 import React, { Component, createRef } from "react"
-import { Link } from "react-router-dom"
+import { Link, Route } from "react-router-dom"
 import "./Header.css"
 import logo from "../assets/rt_logo.png"
 
@@ -47,7 +47,7 @@ class Header extends Component {
         onKeyDown={(e) => this.handleKeyDown(e)}
         tabIndex={1}
         role="button"
-        ariaLabel="search movies by title"
+        aria-label="search movies by title"
       >search</i>
       <input 
         className={inputClassList}
@@ -60,8 +60,6 @@ class Header extends Component {
         ref={this.state.searchInput}
       />
     </div>
-
-    const displaySearchOK = !this.props.movieId && !this.props.err
 
     return (
       <header>
@@ -76,7 +74,7 @@ class Header extends Component {
           </Link>
         </div>
         <div className="header-right">
-          {displaySearchOK && searchBar}
+          <Route exact path="/" render={ () => searchBar} />
         </div>
       </header>
     )

--- a/src/Header/Header.js
+++ b/src/Header/Header.js
@@ -32,12 +32,12 @@ class Header extends Component {
 
   render() {
     const inputClassList = this.state.searchHidden ? 
-    `search-input` :
-    `search-input input-transition` 
-    
+      `search-input` :
+      `search-input input-transition` 
+
     const iconClassList = this.state.searchHidden ? 
-    `material-symbols-outlined` :
-    `material-symbols-outlined icon-transition`
+      `material-symbols-outlined` :
+      `material-symbols-outlined icon-transition`
 
     const searchBar = 
     <div className="input-container">

--- a/src/Header/Header.js
+++ b/src/Header/Header.js
@@ -1,5 +1,5 @@
 import React, { Component, createRef } from "react"
-
+import { Link } from "react-router-dom"
 import "./Header.css"
 import logo from "../assets/rt_logo.png"
 
@@ -62,14 +62,14 @@ class Header extends Component {
     return (
       <header>
         <div className="header-left">
-          <div className="title-container">
+          <Link to="/" className="title-container">
             <img 
               className="logo" 
               src={logo}
               alt="Rancid Tomatillos logo"
             />
             <h1>RANCID <br />TOMATILLOS</h1>
-          </div>
+          </Link>
         </div>
         <div className="header-right">
           {displaySearchOK && searchBar}

--- a/src/Header/Header.js
+++ b/src/Header/Header.js
@@ -31,22 +31,26 @@ class Header extends Component {
   }
 
   render() {
+    const inputClassList = this.state.searchHidden ? 
+    `search-input` :
+    `search-input input-transition` 
+    
+    const iconClassList = this.state.searchHidden ? 
+    `material-symbols-outlined` :
+    `material-symbols-outlined icon-transition`
+
     const searchBar = 
     <div className="input-container">
       <i 
-        className={this.state.searchHidden ? 
-          `material-symbols-outlined` :
-          `material-symbols-outlined icon-transition`
-        }
+        className={iconClassList}
         onClick={this.handleIconClick}
         onKeyDown={(e) => this.handleKeyDown(e)}
         tabIndex={1}
+        role="button"
+        ariaLabel="search movies by title"
       >search</i>
       <input 
-        className={this.state.searchHidden ? 
-          `search-input` :
-          `search-input input-transition` 
-        }
+        className={inputClassList}
         type="search" 
         name="search"
         placeholder="search by title" 

--- a/src/Tile/Tile.css
+++ b/src/Tile/Tile.css
@@ -44,6 +44,7 @@ li {
 }
 
 .overlay-text {
+  color: white;
   animation: fadeIn .5s;
 }
 

--- a/src/Tile/Tile.js
+++ b/src/Tile/Tile.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom'
 import "./Tile.css"
 
 import star from "../assets/star.png"
@@ -17,14 +17,21 @@ function Tile({ title, year, img, rating, id }) {
       <p className="overlay-text">{`(${year.slice(0, 4)})`}</p>
     </div>
 
+  const handleKeyDown = e => {
+    if (e.key === "Enter") {
+      e.target.firstChild.click()
+    }
+  }
+
   return (
-    <Link to={`/${id}`}>
-      <li 
+    <li 
       data-cy={`${id}`}
       tabIndex={1}
+      onKeyDown={e => handleKeyDown(e)}
       onFocus={() => setHover(true)}
       onBlur={() => setHover(false)}
       >
+      <Link to={`/${id}`}>
         <div className="img-container">
           <img 
             className={hovering ? `hover-animation tile-img` : 
@@ -36,11 +43,11 @@ function Tile({ title, year, img, rating, id }) {
           />
           {hovering && overlay}
         </div>
-        <p className="tile-rating">{rating.toFixed(1)} 
-          <img className="star" src={star}/>
-        </p>
-      </li>
-    </Link>
+      </Link>
+      <p className="tile-rating">{rating.toFixed(1)} 
+        <img className="star" src={star}/>
+      </p>
+    </li>
   )
 }
 

--- a/src/Tile/Tile.js
+++ b/src/Tile/Tile.js
@@ -7,6 +7,12 @@ import star from "../assets/star.png"
 function Tile({ title, year, img, rating, id }) {
   const [ hovering, setHover ] = useState(false)
 
+  const handleKeyDown = e => {
+    if (e.key === "Enter") {
+      e.target.firstChild.click()
+    }
+  }
+
   const overlay = 
     <div 
       className="overlay"
@@ -17,16 +23,14 @@ function Tile({ title, year, img, rating, id }) {
       <p className="overlay-text">{`(${year.slice(0, 4)})`}</p>
     </div>
 
-  const handleKeyDown = e => {
-    if (e.key === "Enter") {
-      e.target.firstChild.click()
-    }
-  }
+  const imageClassList = hovering ? 
+    `hover-animation tile-img` : 
+    `tile-img`
 
   return (
     <li 
       data-cy={`${id}`}
-      tabIndex={1}
+      tabIndex={2}
       onKeyDown={e => handleKeyDown(e)}
       onFocus={() => setHover(true)}
       onBlur={() => setHover(false)}
@@ -34,8 +38,7 @@ function Tile({ title, year, img, rating, id }) {
       <Link to={`/${id}`}>
         <div className="img-container">
           <img 
-            className={hovering ? `hover-animation tile-img` : 
-              `tile-img`}
+            className={imageClassList}
             src={img} 
             alt={title} 
             onMouseEnter={() => setHover(true)}


### PR DESCRIPTION
**What does this PR do?**

This PR fixes an issue with keyboard navigation on the "all movies" page. It also includes refactors suggested by Heather in [this PR](https://github.com/jwasmer/RancidTomatillos/pull/8).

**Where should your reviewer start?**

Verify "all movies" page can be fully navigated by keyboard. 

**What (if anything) did you refactor?**

- a handler for `keyDown` events was added to the `Tile` component to allow a user to select a movie and navigate to the "movie detail" page.
- tab index of `Tile` components were changed to 2 for easier keyboard navigation.
- `<i>` element in `Header` was given an ARIA role of "button" and appropriate ARIA label.
- ternaries which were conditionally rendering various elements in `Tile` and `Header` components were broken out into variables for better readability.
- In `Header`, the parent container of the `<h1>` element and logo image were changed to a `<Link>` component, which now takes the user back to the "all movies" page.
- replaces conditional rendering of the search bar (previously using `movieId` state) with `Route` component
