### PR TITLE
Feature/detailview unavailable data

### DIFF
--- a/src/DetailView/DetailView.js
+++ b/src/DetailView/DetailView.js
@@ -30,7 +30,8 @@ class DetailView extends Component {
         this.setState({
           averageRating: data.average_rating,
           backdropPath: data.backdrop_path,
-          budget: data.budget.toLocaleString(),
+          budget: data.budget,
+          displayedBudget: data.budget.toLocaleString(),
           genres: data.genres.join(" | "),
           id: data.id,
           overview: data.overview,
@@ -38,7 +39,8 @@ class DetailView extends Component {
           releaseDate: releaseDateObject,
           dateData: dateData,
           dateYear: dateYear,
-          revenue: data.revenue.toLocaleString(),
+          revenue: data.revenue,
+          displayedRevenue: data.revenue.toLocaleString(),
           runtime: data.runtime,
           title: data.title
         })
@@ -116,11 +118,11 @@ class DetailView extends Component {
               </tr>
               <tr>
                 <td className="movie-info">budget: </td>
-                <td data-cy="budget" className="movie-info">${this.state.budget}</td>
+                {this.state.budget ? <td data-cy="budget" className="movie-info">${this.state.displayedBudget}</td> : <td data-cy="budget" className="movie-info">unavailable</td>}
               </tr>
               <tr>
                 <td className="movie-info">box office: </td>
-                <td data-cy="revenue" className="movie-info">${this.state.revenue}</td>
+                {this.state.revenue ? <td data-cy="revenue" className="movie-info">${this.state.displayedRevenue}</td> : <td data-cy="revenue" className="movie-info">unavailable</td>}
               </tr>
             </tbody>
           </table>

--- a/src/DetailView/DetailView.js
+++ b/src/DetailView/DetailView.js
@@ -9,7 +9,9 @@ class DetailView extends Component {
     super(props)
     this.movieId = this.props.movieId
     this.closeMovie = this.props.closeMovie
-    this.state = {}
+    this.state = {
+      loadingComplete: false
+    }
   }
 
   componentDidMount() {
@@ -28,6 +30,7 @@ class DetailView extends Component {
         const dateYear = releaseDateObject.getFullYear()
 
         this.setState({
+          loadingComplete: true,
           averageRating: data.average_rating,
           backdropPath: data.backdrop_path,
           budget: data.budget,
@@ -78,7 +81,7 @@ class DetailView extends Component {
       </iframe>
 
     return <>
-      <section 
+      {this.state.loadingComplete && <section 
         data-cy="backdrop"
         className="details-container" 
         style={{
@@ -128,7 +131,7 @@ class DetailView extends Component {
           </table>
         </div>
         <p data-cy="rating" className="rating">average rating: {Math.round(this.state.averageRating)} ⭐️</p>
-      </section>
+      </section>}
 
       {this.state.videoUrl && videoElement}
 


### PR DESCRIPTION
**What does this PR do?**
Updates `DetailView` to hide data fields when data is unavailable, or to present the data field as unavailable if it accurate data is not returned.

**Where should your reviewer start?**
Line 13 in `DetailView` adds a `loadingComplete` state, then check line 33 and line 84. Then, review lines 124 and 128 to check the changes to budget and revenue.

**What (if any) features are you implementing?**
Updating logic so page does not render completely until GET promise has returned

**What (if anything) did you refactor?**

**Were there any issues that arose?**

**Is there anything that you need from your teammate?**

**Any other comments, questions, or concerns to add?**
Couldn't figure out a way to hide the budget and revenue lines when the dollar value is $0 without it affecting the rest of the page's styling for some reason that I don't fully understand. I opted to replace the text with "unavailable" instead, let me know what you think of the solution. We can try out other ideas if you'd like.
